### PR TITLE
Potential fix for code scanning alert no. 4: DOM text reinterpreted as HTML

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -53,6 +53,21 @@
         import { initializeApp } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-app.js";
         import { getFirestore, collection, query, where, getDocs, orderBy } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
 
+        // Helper function to escape HTML special characters
+        function escapeHtml(str) {
+            return str.replace(/[&<>"'`]/g, function (match) {
+                switch (match) {
+                    case "&": return "&amp;";
+                    case "<": return "&lt;";
+                    case ">": return "&gt;";
+                    case '"': return "&quot;";
+                    case "'": return "&#39;";
+                    case "`": return "&#96;";
+                    default: return match;
+                }
+            });
+        }
+
         document.addEventListener('DOMContentLoaded', async () => {
             const postsContainer = document.getElementById('blog-posts-container');
             const loadingIndicator = document.getElementById('loading-indicator');
@@ -90,7 +105,7 @@
                         articlesHtml += `
                             <article class="blog-card">
                                 <h3>${post.title}</h3>
-                                <p>${summary}</p>
+                                <p>${escapeHtml(summary)}</p>
                                 <a href="/blogs/post.html?id=${post.id}">Read More &rarr;</a>
                             </article>
                         `;


### PR DESCRIPTION
Potential fix for [https://github.com/SansMercantile/SansMercantile.github.io/security/code-scanning/4](https://github.com/SansMercantile/SansMercantile.github.io/security/code-scanning/4)

To fix the problem, we need to ensure that any text derived from untrusted sources (in this case, the summary extracted from `textContent`) is properly escaped before being inserted into the DOM via `innerHTML`. The best way to do this is to escape HTML meta-characters (`&`, `<`, `>`, `"`, `'`, and `` ` ``) in the summary string. This can be done by defining a helper function (e.g., `escapeHtml`) that replaces these characters with their corresponding HTML entities. The fix should be applied in the region where the summary is interpolated into the HTML string (line 93). The `escapeHtml` function can be defined within the same script block.

**Steps:**
- Add an `escapeHtml` function at the top of the script block.
- Use `escapeHtml(summary)` when interpolating the summary into the HTML string on line 93.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
