### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 # .github/workflows/build-for-github.yml
 
 name: Build and Test on GitHub
+permissions:
+  contents: write
+  packages: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/SansMercantile/SansMercantile.github.io/security/code-scanning/1](https://github.com/SansMercantile/SansMercantile.github.io/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow file. This can be done at the top level (applies to all jobs) or at the job level (for more granular control). Since both jobs in this workflow use the `GITHUB_TOKEN` for write operations (`contents: write` for deploying to GitHub Pages, `packages: write` for pushing to GHCR), you should set these permissions explicitly. The minimal required permissions for this workflow are:

- `contents: write` (for deploying to GitHub Pages)
- `packages: write` (for pushing Docker images to GHCR)

Add the following block near the top of the workflow file, after the `name:` and before `on:`:

```yaml
permissions:
  contents: write
  packages: write
```

This ensures that the `GITHUB_TOKEN` only has the permissions needed for the workflow to function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
