### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-demo.yml
+++ b/.github/workflows/build-demo.yml
@@ -1,4 +1,6 @@
 name: Build and Deploy Demo
+permissions:
+  contents: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/SansMercantile/SansMercantile.github.io/security/code-scanning/8](https://github.com/SansMercantile/SansMercantile.github.io/security/code-scanning/8)

The recommended fix is to add a `permissions` block to this workflow specifying the minimal required scopes for the operations being performed. For the `peaceiris/actions-gh-pages@v3` deployment step, this generally requires the `contents: write` permission so that files can be pushed to the `gh-pages` branch. The `permissions` block should be set at the job level (inside `build-and-deploy:`) or at the workflow level (top-level, applies to all jobs). Here, since there is a single job, either is fine, but setting it at the workflow root is common and future-proof for more jobs. The change should be applied to the file `.github/workflows/build-demo.yml`, adding a block like:

```yaml
permissions:
  contents: write
```

directly after the workflow `name` (before `on:`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
